### PR TITLE
Add Modulefile of modules for git repository under subdirectories  

### DIFF
--- a/lib/librarian/puppet/source/repository.rb
+++ b/lib/librarian/puppet/source/repository.rb
@@ -1,0 +1,57 @@
+require 'librarian/source/git/repository'
+
+module Librarian
+  module Puppet
+    module Source
+      class Repository < ::Librarian::Source::Git::Repository
+
+        def initialize(environment, path, module_path)
+          @module_path = module_path.to_s
+          super environment, path
+        end
+
+        def hash_from(remote, reference)
+          branch_names = remote_branch_names[remote]
+          if branch_names.include?(reference)
+            reference = "#{remote}/#{reference}"
+          end
+
+          command = %W(rev-parse #{reference}^{commit} --quiet)
+          run!(command, :chdir => true).strip
+        end
+
+        # Naming this method 'version' causes an exception to be raised.
+        def module_version
+          return '0.0.1' unless modulefile?
+
+          metadata  = ::Puppet::ModuleTool::Metadata.new
+          ::Puppet::ModuleTool::ModulefileReader.evaluate(metadata, modulefile)
+
+          metadata.version
+        end
+
+        def dependencies
+          return {} unless modulefile?
+
+          metadata = ::Puppet::ModuleTool::Metadata.new
+
+          ::Puppet::ModuleTool::ModulefileReader.evaluate(metadata, modulefile)
+
+          metadata.dependencies.inject({}) do |h, dependency|
+            name = dependency.instance_variable_get(:@full_module_name)
+            version = dependency.instance_variable_get(:@version_requirement)
+            h.update(name => version)
+          end
+        end
+
+        def modulefile
+          File.join(path, @module_path, 'Modulefile')
+        end
+
+        def modulefile?
+          File.exists?(modulefile)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Make git repositories with puppet modules under a subdirectory contribute to the dependency resolution

Some times the git repository contains a group of modules as subdirectories. One example is https://github.com/example42/puppet-modules

When it happens, the Modulefile for the project specified is not being picked up, and their dependencies are not resolving. This is a feature supported by Librarian.

This pull request is addressing this issue.

To make it easier to check the error, I created a [repo](https://bitbucket.org/bltavares/example-puppet-modulefile-subdir) with a module as a subdirectory.

Then use this `Puppetfile`:

``` ruby
forge "http://forge.puppetlabs.com"

mod 'apt-avahi',
    :git => 'https://bitbucket.org/bltavares/example-puppet-modulefile-subdir.git',
    :path => 'apt-avahi'
```

Before applying the patch, you will find this dir structure under `modules`:

``` bash
% ls modules
apt-avahi
```

After applying the patch, the `modules` dir will contain the resolved modules:

``` bash
% ls modules
apt       apt-avahi avahi     stdlib
```
