### PR TITLE
Return the resolved version for git repos

### DIFF
--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -103,6 +103,7 @@ module Librarian
             debug { "Ignoring invalid version '#{v}' for module #{name}, using 0.0.1" }
             v = '0.0.1'
           end
+          v
         end
 
         def fetch_dependencies(name, version, extra)


### PR DESCRIPTION
The fetch_version method is supposed to produce the version of the module.
Modifications to git.rb in 44bcd59b altered the return value to (in some cases)
the boolean value of Gem::Version.correct? v

This change fixes https://github.com/maestrodev/librarian-puppet/issues/5
