### PR TITLE
Improves caching so that same git repo/ref but different path doesn't ca...

### DIFF
--- a/vendor/librarian/lib/librarian/source/git.rb
+++ b/vendor/librarian/lib/librarian/source/git.rb
@@ -144,9 +144,8 @@ module Librarian
       def cache_key
         @cache_key ||= begin
           uri_part = uri
-          path_part = "/#{path}" if path
           ref_part = "##{ref}"
-          key_source = [uri_part, path_part, ref_part].join
+          key_source = [uri_part, ref_part].join
           Digest::MD5.hexdigest(key_source)
         end
       end


### PR DESCRIPTION
...che multiple copies.

Prior to this change we had a single repo/ref that was used in 10+ modules in the Puppetfile and each was creating a separate cache.  This resolves that so that there is a single repo cached in this case.  Change was very simple.
